### PR TITLE
template for adding CLI tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,8 +53,8 @@ homepage = "https://github.com/bbarad/ETSegTools"
 repository = "https://github.com/bbarad/ETSegTools"
 
 # same as console_scripts entry point
-# [project.scripts]
-# spam-cli = "spam:main_cli"
+[project.scripts]
+etsegops = "etsegops.package_containing_cli:main_cli_func"
 
 # Entry points
 # https://peps.python.org/pep-0621/#entry-points


### PR DESCRIPTION
to add CLI tools you will need to move a script into the package somewhere then reference it from here in the pyproject.toml with the syntax shown in this PR

It's sometimes good to expose functionality from one package in one command with multiple subcommands 


e.g. `etsegops` at the cli would have `rescale`, `smooth` and whatever else, then those might have `dragonfly` and `other_package` subcommands themselves - namespacing this way can make exploring what your package provides quite discoverable, you see it all when you type `etsegops` and look at the help page

I recommend using [typer](https://typer.tiangolo.com/) over click as you get quite a few niceties for free

```python
import typer

# in some place you want to store the top level CLI
cli = typer.Typer(no_args_is_help=True, add_completion=True)

# in other places where you want to add subcommands
from ..cli import cli

@cli.command(name='subcommand_name')
def my_func(arg1: Path, arg2: float):
    pass # do stuff
```